### PR TITLE
Persist workflow state to avoid Vercel 404

### DIFF
--- a/defense-ai-research/lib/utils/workflow-store.ts
+++ b/defense-ai-research/lib/utils/workflow-store.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { WorkflowState } from '../../types/agents';
+
+const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '.workflow-data';
+
+function ensureDir() {
+  if (!fs.existsSync(WORKFLOW_DIR)) {
+    fs.mkdirSync(WORKFLOW_DIR, { recursive: true });
+  }
+}
+
+export function saveWorkflowState(id: string, state: WorkflowState) {
+  try {
+    ensureDir();
+    const filePath = path.join(WORKFLOW_DIR, `${id}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(state, null, 2), 'utf8');
+  } catch (err) {
+    console.error(`Failed to save workflow state ${id}:`, err);
+  }
+}
+
+export function loadWorkflowState(id: string): WorkflowState | null {
+  try {
+    const filePath = path.join(WORKFLOW_DIR, `${id}.json`);
+    if (fs.existsSync(filePath)) {
+      const data = fs.readFileSync(filePath, 'utf8');
+      return JSON.parse(data) as WorkflowState;
+    }
+  } catch (err) {
+    console.error(`Failed to load workflow state ${id}:`, err);
+  }
+  return null;
+}

--- a/defense-ai-research/lib/workflow/orchestrator.ts
+++ b/defense-ai-research/lib/workflow/orchestrator.ts
@@ -1,6 +1,7 @@
 import { UserInput, StartupFirm } from '../../types/agents';
 import { WorkflowStateManager } from './state-manager';
 import { parseStartupFirmsFile } from '../utils/file-parser';
+import { saveWorkflowState } from '../utils/workflow-store';
 
 // Import preparatory agents
 import { PrePolicyAgent } from '../agents/preparatory/pre-policy';
@@ -23,9 +24,16 @@ import { HTMLGeneratorAgent } from '../agents/output/html-generator';
 export class ResearchWorkflowOrchestrator {
   private stateManager: WorkflowStateManager;
   private startupFirms: StartupFirm[] = [];
+  private workflowId: string;
 
-  constructor(userInput: UserInput) {
+  constructor(workflowId: string, userInput: UserInput) {
+    this.workflowId = workflowId;
     this.stateManager = new WorkflowStateManager({ userInput });
+    // Persist state on every update
+    this.stateManager.subscribeToAll(() => {
+      saveWorkflowState(this.workflowId, this.stateManager.getState());
+    });
+    saveWorkflowState(this.workflowId, this.stateManager.getState());
   }
 
   async execute(): Promise<string> {


### PR DESCRIPTION
## Summary
- store workflow states in `.workflow-data/` so later requests can load them
- make `ResearchWorkflowOrchestrator` aware of its workflow ID and persist state on updates
- update research API to save state and fall back to disk when workflows aren't in memory

## Testing
- `npm run verify`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68846fad78ec8324944f1f3f9367884d