### PR TITLE
Fix workflow directory for vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The main application is located in the `defense-ai-research/` directory. See the
    ```bash
    cp .env.local.example .env.local
    # Edit .env.local with your API keys
+   # Optionally set WORKFLOW_DIR to control where workflow state is saved
    ```
 
 4. **Run the development server**:

--- a/defense-ai-research/README.md
+++ b/defense-ai-research/README.md
@@ -82,6 +82,10 @@ GEMINI_TOKEN_LIMIT=4000000
 GEMINI_WINDOW_MS=60000
 GEMINI_INPUT_COST_PER_MILLION=0.10
 GEMINI_OUTPUT_COST_PER_MILLION=0.40
+
+# Workflow State Directory
+# Optional: where to store workflow progress on disk
+WORKFLOW_DIR=/tmp/workflow-data
 ```
 
 ### Model Configuration

--- a/defense-ai-research/lib/utils/workflow-store.ts
+++ b/defense-ai-research/lib/utils/workflow-store.ts
@@ -1,8 +1,10 @@
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { WorkflowState } from '../../types/agents';
 
-const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '.workflow-data';
+const WORKFLOW_DIR =
+  process.env.WORKFLOW_DIR || path.join(os.tmpdir(), 'workflow-data');
 
 function ensureDir() {
   if (!fs.existsSync(WORKFLOW_DIR)) {


### PR DESCRIPTION
## Summary
- fix workflow-store default path to write under OS temp directory
- document optional WORKFLOW_DIR environment variable

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850822d1a88324832a4667f8de09fc