### PR TITLE
Fix workflow storage path and CSV parsing

### DIFF
--- a/defense-ai-research/lib/agents/preparatory/base.ts
+++ b/defense-ai-research/lib/agents/preparatory/base.ts
@@ -27,7 +27,7 @@ export abstract class BasePreparatoryAgent {
       try {
         console.log(`🔍 Searching: ${query}`);
         const result = await this.firecrawl.search(query, {
-          timeout: 15000,
+          timeout: 30000,
           limit: 3,
           scrapeOptions: { formats: ['markdown'] },
         });

--- a/defense-ai-research/lib/deep-research/deep-research.ts
+++ b/defense-ai-research/lib/deep-research/deep-research.ts
@@ -56,7 +56,7 @@ async function searchWithRetry(query: string, retryCount = 0): Promise<SearchRes
     console.log(`Rate limit status: ${remaining} searches remaining this minute (resets at ${resetTime.toLocaleTimeString()})`);
     
     const result = await firecrawl.search(query, {
-      timeout: 15000,
+      timeout: 30000,
       limit: 5,
       scrapeOptions: { formats: ['markdown'] },
     });

--- a/defense-ai-research/lib/utils/file-parser.ts
+++ b/defense-ai-research/lib/utils/file-parser.ts
@@ -22,14 +22,16 @@ export async function parseStartupFirmsFile(file: File): Promise<StartupFirm[]> 
 }
 
 function parseCSV(text: string): StartupFirm[] {
+  // Detect delimiter (comma vs tab)
+  const delimiter = text.includes('\t') && !text.includes(',') ? '\t' : ',';
   const lines = text.split('\n').filter(line => line.trim());
   if (lines.length < 2) return [];
-  
-  const headers = lines[0].split(',').map(h => h.trim().toLowerCase());
+
+  const headers = lines[0].split(delimiter).map(h => h.trim().toLowerCase());
   const firms: StartupFirm[] = [];
-  
+
   for (let i = 1; i < lines.length; i++) {
-    const values = lines[i].split(',').map(v => v.trim());
+    const values = lines[i].split(delimiter).map(v => v.trim());
     const firm: StartupFirm = { name: '', description: '', products: [], website: '' };
     
     headers.forEach((header, index) => {

--- a/defense-ai-research/lib/utils/workflow-store.ts
+++ b/defense-ai-research/lib/utils/workflow-store.ts
@@ -2,7 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { WorkflowState } from '../../types/agents';
 
-const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '.workflow-data';
+// Default to /tmp to ensure write access in serverless environments
+const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '/tmp/deepdefense-workflows';
 
 function ensureDir() {
   if (!fs.existsSync(WORKFLOW_DIR)) {


### PR DESCRIPTION
## Summary
- parse CSV files with tabs as delimiters
- store workflow state under `/tmp` by default so writes succeed
- increase Firecrawl search timeout in agents

## Testing
- `npm run lint` *(fails: npm install blocked by no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68850822d1a88324832a4667f8de09fc