### PR TITLE
Fix workflow storage path

### DIFF
--- a/defense-ai-research/README.md
+++ b/defense-ai-research/README.md
@@ -76,6 +76,10 @@ FIRECRAWL_SEARCH_LIMIT=5
 FIRECRAWL_SCRAPE_LIMIT=10
 FIRECRAWL_CONCURRENCY_LIMIT=1
 
+# Optional workflow state directory. Defaults to `/tmp/workflow-data` on
+# serverless deployments like Vercel.
+WORKFLOW_DIR=/tmp/workflow-data
+
 # Rate Limiting
 GEMINI_REQUEST_LIMIT=2000
 GEMINI_TOKEN_LIMIT=4000000
@@ -151,6 +155,7 @@ Company B,Maritime AI systems,Navigation AI;Port security,https://example.com
 2. Set environment variables in Vercel dashboard:
    - `GEMINI_API_KEY`
    - `FIRECRAWL_KEY`
+   - `WORKFLOW_DIR` (optional, defaults to `/tmp/workflow-data`)
 3. Deploy automatically with each push
 
 ### Manual Build

--- a/defense-ai-research/lib/utils/workflow-store.ts
+++ b/defense-ai-research/lib/utils/workflow-store.ts
@@ -2,7 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import { WorkflowState } from '../../types/agents';
 
-const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '.workflow-data';
+// Vercel's serverless functions have a read-only filesystem except for `/tmp`.
+// Use that location by default so workflow state can be persisted without errors
+// when no `WORKFLOW_DIR` is provided via environment variables.
+const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '/tmp/workflow-data';
 
 function ensureDir() {
   if (!fs.existsSync(WORKFLOW_DIR)) {


### PR DESCRIPTION
## Summary
- default workflow cache directory to `/tmp` for serverless compatibility
- document `WORKFLOW_DIR` setting in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68850822d1a88324832a4667f8de09fc