### PR TITLE
Fix build by removing unavailable Vercel KV dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ The main application is located in the `defense-ai-research/` directory. See the
    # On serverless platforms you must also set WORKFLOW_DIR to a writable path
    # For example on Vercel use:
    #   WORKFLOW_DIR=/tmp/deepdefense-workflows
-   # If using Vercel Redis (e.g. "redis-yellow-tree"), set:
-   #   UPSTASH_REDIS_REST_URL=<your redis url>
-   #   UPSTASH_REDIS_REST_TOKEN=<your redis token>
    ```
 
 4. **Run the development server**:

--- a/defense-ai-research/.env.local.example
+++ b/defense-ai-research/.env.local.example
@@ -8,7 +8,4 @@ GEMINI_TOP_P=0.95
 GEMINI_TOP_K=40
 GEMINI_MAX_OUTPUT_TOKENS=8192
 WORKFLOW_DIR=/tmp/deepdefense-workflows
-# Optional Redis configuration for Vercel
-# UPSTASH_REDIS_REST_URL=
-# UPSTASH_REDIS_REST_TOKEN=
 

--- a/defense-ai-research/README.md
+++ b/defense-ai-research/README.md
@@ -85,9 +85,6 @@ GEMINI_OUTPUT_COST_PER_MILLION=0.40
 
 # Directory to persist workflow state
 WORKFLOW_DIR=/tmp/deepdefense-workflows
-# Optional Redis configuration for Vercel Storage
-UPSTASH_REDIS_REST_URL=your_redis_url
-UPSTASH_REDIS_REST_TOKEN=your_redis_token
 ```
 
 ### Model Configuration

--- a/defense-ai-research/lib/utils/workflow-store.ts
+++ b/defense-ai-research/lib/utils/workflow-store.ts
@@ -1,14 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { kv } from '@vercel/kv';
 import { WorkflowState } from '../../types/agents';
 
 // Default to /tmp to ensure write access in serverless environments
 const WORKFLOW_DIR = process.env.WORKFLOW_DIR || '/tmp/deepdefense-workflows';
 
-// If Vercel Redis (Upstash) environment variables are present, use Redis
-const USE_REDIS =
-  !!process.env.UPSTASH_REDIS_REST_URL && !!process.env.UPSTASH_REDIS_REST_TOKEN;
 
 function ensureDir() {
   if (!fs.existsSync(WORKFLOW_DIR)) {
@@ -17,14 +13,6 @@ function ensureDir() {
 }
 
 export async function saveWorkflowState(id: string, state: WorkflowState) {
-  if (USE_REDIS) {
-    try {
-      await kv.set(id, JSON.stringify(state));
-      return;
-    } catch (err) {
-      console.error(`Failed to save workflow state ${id} to Redis:`, err);
-    }
-  }
   try {
     ensureDir();
     const filePath = path.join(WORKFLOW_DIR, `${id}.json`);
@@ -35,14 +23,6 @@ export async function saveWorkflowState(id: string, state: WorkflowState) {
 }
 
 export async function loadWorkflowState(id: string): Promise<WorkflowState | null> {
-  if (USE_REDIS) {
-    try {
-      const data = await kv.get<string>(id);
-      return data ? (JSON.parse(data) as WorkflowState) : null;
-    } catch (err) {
-      console.error(`Failed to load workflow state ${id} from Redis:`, err);
-    }
-  }
   try {
     const filePath = path.join(WORKFLOW_DIR, `${id}.json`);
     if (fs.existsSync(filePath)) {

--- a/defense-ai-research/package.json
+++ b/defense-ai-research/package.json
@@ -21,8 +21,7 @@
     "p-limit": "^6.2.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "zod": "^3.25.76",
-    "@vercel/kv": "^1.1.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- remove mention of Upstash env vars from docs
- drop `@vercel/kv` from dependencies
- simplify workflow store to use local filesystem only

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856d0d0d988324bdbcb20f9efce9e0